### PR TITLE
Fixing outdated code that breaks this module

### DIFF
--- a/bin/sideline
+++ b/bin/sideline
@@ -1,6 +1,6 @@
 #!/usr/bin/env coffee
 Sideline = require(__dirname + "/../lib/sideline")
-if process.ARGV[2] == "--self"
+if "--self" in process.argv
   Sideline.server.connect()
 else
   Sideline.connect()

--- a/lib/sideline/server.coffee
+++ b/lib/sideline/server.coffee
@@ -1,7 +1,5 @@
 Net = require("net")
 CoffeeScript = require("coffee-script")
-# Ugly but necessary due to typo in js2coffee package.json
-require.paths.push __dirname + "/../../node_modules/js2coffee/lib"
 JS2Coffee = require("js2coffee")
 Eyes = require("eyes")
 Script = require("vm").Script

--- a/package.json
+++ b/package.json
@@ -9,10 +9,6 @@
   },
   "bin": "./bin/sideline",
   "main": "./lib/sideline.coffee",
-  "files": [
-    "CHANGELOG.md",
-    "README.md"
-  ],
   "engines": {
     "node": ">=0.4.0"
   },


### PR DESCRIPTION
(1) process.ARGV -> process.argv

(2) Removing a hack that messes with `require.paths` which you can't do anymore
